### PR TITLE
Comply with bash being installed in a different path

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 AUTHCODE=$1
 shift
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
First of all thank you a lot for the script. It saves me a lot of time and works pretty reliably. Nevertheless I have two suggestions.

Bash may be installed in a different path. On Mac OS it lives in `/bin/bash` for example.