### PR TITLE
Don't use -r switch on sed as it's not portable

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -7,7 +7,7 @@ while [ $# -gt 0 ]; do
 
     ffmpeg -i "$FILE" 2> tmp.txt
     TITLE=`grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs`
-    TITLE=`echo $TITLE | sed -r 's/\(Unabridged\)//' | xargs`
+    TITLE=`echo $TITLE | sed -e 's/(Unabridged)//' | xargs`
     ARTIST=`grep -a -m1 -h -r "artist" tmp.txt | head -1 | cut -d: -f2- | xargs`
     GENRE=`grep -a -m1 -h -r "genre" tmp.txt | head -1 | cut -d: -f2- | xargs`
     BITRATE=`grep -a -m1 -h -r "bitrate" tmp.txt | head -1 | rev | cut -d: -f 1 | rev | egrep -o [0-9]+ | xargs`


### PR DESCRIPTION
Secondly sed's -r switch is not portable. I'm using -e to achieve the same goal.
https://www.gnu.org/software/sed/manual/html_node/Invoking-sed.html#Invoking-sed