### PR TITLE
Fix for titles with single quotes breaking script

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -6,8 +6,8 @@ while [ $# -gt 0 ]; do
     echo "Decoding $FILE with AUTHCODE $AUTHCODE..."
 
     ffmpeg -i "$FILE" 2> tmp.txt
-    TITLE=`grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs`
-    TITLE=`echo $TITLE | sed -e 's/(Unabridged)//' | xargs`
+    TITLE=`grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs -0`
+    TITLE=`echo $TITLE | sed -e 's/(Unabridged)//' | xargs -0`
     ARTIST=`grep -a -m1 -h -r "artist" tmp.txt | head -1 | cut -d: -f2- | xargs`
     GENRE=`grep -a -m1 -h -r "genre" tmp.txt | head -1 | cut -d: -f2- | xargs`
     BITRATE=`grep -a -m1 -h -r "bitrate" tmp.txt | head -1 | rev | cut -d: -f 1 | rev | egrep -o [0-9]+ | xargs`


### PR DESCRIPTION
This patch fixes #11 and prevents the following error, which happens when a title contains a single quote (e.g. this `tmp.txt` file: https://gist.github.com/pbowyer/7b7d2181da42c4de1d4f947247a47178):
```
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
```