### PR TITLE
General cleanup

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -7,6 +7,8 @@ if ! command -v ffmpeg 2> /dev/null ; then
     exit 1
 fi
 
+trap 'rm -f "tmp.txt"' EXIT TERM
+
 while [ $# -gt 0 ]; do
     FILE="$1"
     echo "$(date "+%F %T%z") Decoding ${FILE} with AUTHCODE ${AUTHCODE}..."
@@ -30,8 +32,8 @@ while [ $# -gt 0 ]; do
     set -x
     while read -r first _ _ start _ end; do
         if [[ "${first}" = "Chapter" ]]; then
-            read
-            read _ _ chapter
+            read -r
+            read -r _ _ chapter
             ffmpeg -v error -stats -i "${OUTPUT}.mp3" -ss "${start%?}" -to "${end}" -acodec copy "${OUTPUT} - ${chapter}.mp3" < /dev/null
             mv "${OUTPUT} - ${chapter}.mp3" "${OUTPUT_DIR}"
             set +x

--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -2,31 +2,31 @@
 AUTHCODE=$1
 shift
 while [ $# -gt 0 ]; do
-    FILE=$1
-    echo "Decoding $FILE with AUTHCODE $AUTHCODE..."
+    FILE="$1"
+    echo "Decoding ${FILE} with AUTHCODE ${AUTHCODE}..."
 
-    ffmpeg -i "$FILE" 2> tmp.txt
-    TITLE=`grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs -0`
-    TITLE=`echo $TITLE | sed -e 's/(Unabridged)//' | xargs -0`
-    ARTIST=`grep -a -m1 -h -r "artist" tmp.txt | head -1 | cut -d: -f2- | xargs`
-    GENRE=`grep -a -m1 -h -r "genre" tmp.txt | head -1 | cut -d: -f2- | xargs`
-    BITRATE=`grep -a -m1 -h -r "bitrate" tmp.txt | head -1 | rev | cut -d: -f 1 | rev | egrep -o [0-9]+ | xargs`
+    ffmpeg -i "${FILE}" 2> tmp.txt
+    TITLE=$(grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs -0)
+    TITLE=$(echo "${TITLE}" | sed -e 's/(Unabridged)//' | xargs -0)
+    ARTIST=$(grep -a -m1 -h -r "artist" tmp.txt | head -1 | cut -d: -f2- | xargs)
+    GENRE=$(grep -a -m1 -h -r "genre" tmp.txt | head -1 | cut -d: -f2- | xargs)
+    BITRATE=$(grep -a -m1 -h -r "bitrate" tmp.txt | head -1 | rev | cut -d: -f 1 | rev | egrep -o [0-9]+ | xargs)
     BITRATE="${BITRATE}k"
-    OUTPUT=`echo $TITLE | sed -e 's/\:/-/g' | xargs -0`
+    OUTPUT=$(echo "${TITLE}" | sed -e 's/\:/-/g' | xargs -0)
     OUTPUT_DIR="${GENRE}/${ARTIST}/${TITLE}"
 
-    ffmpeg -v error -stats -activation_bytes $AUTHCODE -i "${FILE}" -vn -c:a libmp3lame -ab $BITRATE "${OUTPUT}.mp3"
+    ffmpeg -v error -stats -activation_bytes "${AUTHCODE}" -i "${FILE}" -vn -c:a libmp3lame -ab "${BITRATE}" "${OUTPUT}.mp3"
 
     echo "Created ${OUTPUT}.mp3."
 
     echo "Extracting chaptered mp3 files from ${OUTPUT}.mp3..."
     mkdir -p "${OUTPUT_DIR}"
     while read -r first _ _ start _ end; do
-        if [[ $first = Chapter ]]; then
+        if [[ "${first}" = "Chapter" ]]; then
             read
             read _ _ chapter
-            ffmpeg -v error -stats -i "${OUTPUT}.mp3" -ss "${start%?}" -to "$end" -acodec copy "${OUTPUT} - $chapter.mp3" < /dev/null
-            mv "${OUTPUT} - $chapter.mp3" "${OUTPUT_DIR}"
+            ffmpeg -v error -stats -i "${OUTPUT}.mp3" -ss "${start%?}" -to "${end}" -acodec copy "${OUTPUT} - ${chapter}.mp3" < /dev/null
+            mv "${OUTPUT} - ${chapter}.mp3" "${OUTPUT_DIR}"
         fi
     done < tmp.txt
     mv "${OUTPUT}.mp3" "${OUTPUT_DIR}"
@@ -35,7 +35,7 @@ while [ $# -gt 0 ]; do
     rm tmp.txt
 
     echo "Extracting cover into ${OUTPUT_DIR}/cover.jpg..."
-    ffmpeg -v error -activation_bytes $AUTHCODE -i "$FILE" -an -vcodec copy "${OUTPUT_DIR}/cover.jpg"
+    ffmpeg -v error -activation_bytes "${AUTHCODE}" -i "${FILE}" -an -vcodec copy "${OUTPUT_DIR}/cover.jpg"
     echo "Done."
 
     shift

--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -7,7 +7,7 @@ if ! command -v ffmpeg 2> /dev/null ; then
     exit 1
 fi
 
-trap 'rm -f "tmp.txt"' EXIT TERM
+trap 'rm -f "tmp.txt" ; exit 0 ;' EXIT TERM INT
 
 while [ $# -gt 0 ]; do
     FILE="$1"

--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -1,42 +1,50 @@
 #!/usr/bin/env bash
 AUTHCODE=$1
 shift
+
+if ! command -v ffmpeg 2> /dev/null ; then
+    date "+%F %Tz ABORT: ffmpeg is missing"
+    exit 1
+fi
+
 while [ $# -gt 0 ]; do
     FILE="$1"
-    echo "Decoding ${FILE} with AUTHCODE ${AUTHCODE}..."
+    echo "$(date "+%F %T%z") Decoding ${FILE} with AUTHCODE ${AUTHCODE}..."
 
     ffmpeg -i "${FILE}" 2> tmp.txt
-    TITLE=$(grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs -0)
-    TITLE=$(echo "${TITLE}" | sed -e 's/(Unabridged)//' | xargs -0)
-    ARTIST=$(grep -a -m1 -h -r "artist" tmp.txt | head -1 | cut -d: -f2- | xargs)
-    GENRE=$(grep -a -m1 -h -r "genre" tmp.txt | head -1 | cut -d: -f2- | xargs)
-    BITRATE=$(grep -a -m1 -h -r "bitrate" tmp.txt | head -1 | rev | cut -d: -f 1 | rev | egrep -o [0-9]+ | xargs)
+    TITLE=$(grep -a -m1 -h -r "title" tmp.txt | head -1 | cut -d: -f2- | xargs echo )
+    TITLE=$(echo "${TITLE}" | sed -e 's/ (Unabridged)//' | xargs echo )
+    ARTIST=$(grep -a -m1 -h -r "artist" tmp.txt | head -1 | cut -d: -f2- | xargs echo )
+    GENRE=$(grep -a -m1 -h -r "genre" tmp.txt | head -1 | cut -d: -f2- | xargs echo )
+    BITRATE=$(grep -a -m1 -h -r "bitrate" tmp.txt | head -1 | rev | cut -d: -f 1 | rev | egrep -o [0-9]+ | xargs echo )
     BITRATE="${BITRATE}k"
-    OUTPUT=$(echo "${TITLE}" | sed -e 's/\:/-/g' | xargs -0)
+    OUTPUT=$(echo "${TITLE}" | sed -e 's/\:/-/g' | xargs echo )
     OUTPUT_DIR="${GENRE}/${ARTIST}/${TITLE}"
 
     ffmpeg -v error -stats -activation_bytes "${AUTHCODE}" -i "${FILE}" -vn -c:a libmp3lame -ab "${BITRATE}" "${OUTPUT}.mp3"
 
-    echo "Created ${OUTPUT}.mp3."
+    echo "$(date "+%F %T%z") Created ${OUTPUT}.mp3."
 
-    echo "Extracting chaptered mp3 files from ${OUTPUT}.mp3..."
+    echo "$(date "+%F %T%z") Extracting chaptered mp3 files from ${OUTPUT}.mp3..."
     mkdir -p "${OUTPUT_DIR}"
+    set -x
     while read -r first _ _ start _ end; do
         if [[ "${first}" = "Chapter" ]]; then
             read
             read _ _ chapter
             ffmpeg -v error -stats -i "${OUTPUT}.mp3" -ss "${start%?}" -to "${end}" -acodec copy "${OUTPUT} - ${chapter}.mp3" < /dev/null
             mv "${OUTPUT} - ${chapter}.mp3" "${OUTPUT_DIR}"
+            set +x
         fi
     done < tmp.txt
     mv "${OUTPUT}.mp3" "${OUTPUT_DIR}"
-    echo "Done creating chapters. Single file and chaptered files contained in ${OUTPUT_DIR}."
+    echo "$(date "+%F %T%z") Done creating chapters. Single file and chaptered files contained in ${OUTPUT_DIR}."
 
     rm tmp.txt
 
-    echo "Extracting cover into ${OUTPUT_DIR}/cover.jpg..."
+    echo "$(date "+%F %T%z") Extracting cover into ${OUTPUT_DIR}/cover.jpg..."
     ffmpeg -v error -activation_bytes "${AUTHCODE}" -i "${FILE}" -an -vcodec copy "${OUTPUT_DIR}/cover.jpg"
-    echo "Done."
+    echo "$(date "+%F %T%z") Done."
 
     shift
 done


### PR DESCRIPTION
- Add check for ffpmeg command, fail if it's missing
- Use parenthesis instead of backticks - BashFAQ/082 / shellcheck SC2006
- Use `xargs echo` vs bare `xargs` to prevent execution of commands that appear in the title
- Echo date with status updates
- Safe quotes - shellcheck SC2086
- Consistent variable braces
- use `read -r` to safely handle slashes - shellcheck SC2162
- trap exit and cleanup tmp.txt