### PR TITLE
Fix deleting full audio file in chaptered mode

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -85,7 +85,7 @@ do
                 ffmpeg -loglevel error -stats -i "${full_file_path}" -ss "${start%?}" -to "${end}" -codec:a copy "${chapter_file}"
             fi
         done 9< "$metadata_file"
-        rm ${full_file_path}
+        rm "${full_file_path}"
         debug "Done creating chapters. Chaptered files contained in ${output_directory}."
     fi
 


### PR DESCRIPTION
Quotes are required for rm to properly parse the params. Otherwise spaces separate the file path into several params and the script dies.