### PR TITLE
Make the script OSX compatible

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -35,8 +35,8 @@ debug() {
     echo "$(date "+%F %T%z") ${1}"
 }
 
-trap 'rm --recursive --force "${working_directory}"' EXIT
-working_directory="$(mktemp --directory)"
+trap 'rm -r -f "${working_directory}"' EXIT
+working_directory=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
 metadata_file="${working_directory}/metadata.txt"
 
 save_metadata() {
@@ -48,7 +48,7 @@ save_metadata() {
 get_metadata_value() {
     local key
     key="$1"
-    normalize_whitespace "$(grep --max-count=1 --only-matching "${key} *: .*" "$metadata_file" | cut --delimiter=: --fields=2 | sed -e 's#/##g;s/ (Unabridged)//' | tr -s '[:blank:]' ' ')"
+    normalize_whitespace "$(grep --max-count=1 --only-matching "${key} *: .*" "$metadata_file" | cut -d : -f 2 | sed -e 's#/##g;s/ (Unabridged)//' | tr -s '[:blank:]' ' ')"
 }
 
 get_bitrate() {


### PR DESCRIPTION
The changes were quite simple – mainly shortening command flags. Note that I only have this one OSX machine to try it on, I cannot make sure that those changes are compatible with other systems. Proceed with caution.

- Use shorthand flags for `rm`: `-r` instead of `--recursive`, `-f` instead of `--force`
- Add fallback for `mktemp`. See http://unix.stackexchange.com/a/84980
- Use shorthand flags for `cut`: `-d` instead of `--delimiter`, `-f` instead of `--fields`

Tested on OSX 10.11.6 El Capitan