### PR TITLE
Prevent ffmpeg from showing "Enter command: <target>|all <time>|-1 <command>[ <argument>]" in bash

### DIFF
--- a/AAXtoMP3.sh
+++ b/AAXtoMP3.sh
@@ -71,7 +71,7 @@ do
     mkdir -p "${output_directory}"
     full_file_path="${output_directory}/${title}.${extension}"
 
-    ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${path}" -vn -codec:a "${codec}" -ab "$(get_bitrate)k" -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="$(get_metadata_value album_artist)" -metadata album="$(get_metadata_value album)" -metadata date="$(get_metadata_value date)" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="$(get_metadata_value copyright)" "${full_file_path}"
+    </dev/null ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${path}" -vn -codec:a "${codec}" -ab "$(get_bitrate)k" -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="$(get_metadata_value album_artist)" -metadata album="$(get_metadata_value album)" -metadata date="$(get_metadata_value date)" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="$(get_metadata_value copyright)" "${full_file_path}"
 
     debug "Created ${full_file_path}."
 
@@ -85,7 +85,7 @@ do
                 read -r -u9 _
                 read -r -u9 _ _ chapter
                 chapter_file="${output_directory}/${title} - ${chapter}.${extension}"
-                ffmpeg -loglevel error -stats -i "${full_file_path}" -ss "${start%?}" -to "${end}" -codec:a copy -metadata track="${chapter}" "${chapter_file}"
+                </dev/null ffmpeg -loglevel error -stats -i "${full_file_path}" -ss "${start%?}" -to "${end}" -codec:a copy -metadata track="${chapter}" "${chapter_file}"
             fi
         done 9< "$metadata_file"
         rm "${full_file_path}"
@@ -94,7 +94,7 @@ do
 
     cover_path="${output_directory}/cover.jpg"
     debug "Extracting cover into ${cover_path}..."
-    ffmpeg -loglevel error -activation_bytes "${auth_code}" -i "${path}" -an -codec:v copy "${cover_path}"
+    </dev/null ffmpeg -loglevel error -activation_bytes "${auth_code}" -i "${path}" -an -codec:v copy "${cover_path}"
     debug "Done."
     rm "${metadata_file}"
 done


### PR DESCRIPTION
Prevent ffmpeg from showing "Enter command: <target>|all <time>|-1 <command>[ <argument>]" in bash, tested on Ubuntu 16.06, ffmpeg version 2.8.11

Reference: https://unix.stackexchange.com/a/36411/178221