### PR TITLE
Fix chaptercount for 0-padding

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -68,7 +68,7 @@ normalize_whitespace() {
 }
 
 chapter_padding() {
-    chaptercount=$($GREP -Pc "title\s+:\sChapter\s\d+" $metadata_file)
+    chaptercount=$($GREP -Pc "Chapter.*start.*end" $metadata_file)
     if [[ $chaptercount -gt 9 && $chaptercount -lt 100 ]]
     then
             chapter=$(sed -e 's/Chapter \([[:digit:]]\)$/Chapter 0\1/' <<<$chapter)


### PR DESCRIPTION
Amazon actually does use some other strings as chapter-title than "Chapter <n>". ("Kapitel <n>" in german, for example.)

Getting $chaptercount wrong stops the script and breaks the chapter splitting and cover extraction. (Because of -o errexit i guess.)

grep'ing for the actual chapter line in the metadata.txt for counting chapters seems to be the better way.