### PR TITLE
chg: use authcode file located in HOME dir.

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,6 +5,7 @@ set -o errexit -o noclobber -o nounset -o pipefail
 codec=libmp3lame
 extension=mp3
 mode=chaptered
+authcodeFile="${HOME}/.authcode";
 GREP=$(grep --version | grep -q GNU && echo "grep" || echo "ggrep")
 
 if ! [[ $(type -P "$GREP") ]]; then
@@ -47,11 +48,11 @@ then
     shift
 fi
 
-if [ ! -f .authcode ]; then
+if [ ! -f "$authcodeFile" ]; then
     auth_code=$1
     shift
 else
-    auth_code=`head -1 .authcode`
+    auth_code=`head -1 "$authcodeFile"`
 fi
 
 debug() {

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,7 +5,8 @@ set -o errexit -o noclobber -o nounset -o pipefail
 codec=libmp3lame
 extension=mp3
 mode=chaptered
-authcodeFile="${HOME}/.authcode";
+authcode=".authcode";
+authcodeDirs="${HOME}/ ./";
 GREP=$(grep --version | grep -q GNU && echo "grep" || echo "ggrep")
 
 if ! [[ $(type -P "$GREP") ]]; then
@@ -48,12 +49,26 @@ then
     shift
 fi
 
-if [ ! -f "$authcodeFile" ]; then
-    auth_code=$1
-    shift
-else
-    auth_code=`head -1 "$authcodeFile"`
-fi
+auth_code="";
+for dir in $authcodeDirs; do
+	codeFile="${dir}$authcode";
+
+	if [ ! -f "$codeFile" ]; then
+		auth_code=$1
+		shift
+		break;
+	elif [ -s "$codeFile" ]; then
+		auth_code=`head -1 "$codeFile"`
+		break;
+	else
+		echo "INFO: Sorry, empty \"$codeFile\" found, skipping.";
+	fi;
+done;
+
+if [ -z "$auth_code" ]; then
+	echo "INFO: Sorry, no authcode provided.";
+	exit 1;
+fi;
 
 debug() {
     echo "$(date "+%F %T%z") ${1}"


### PR DESCRIPTION
Hi,
thanks for AAtoMP3.

This change uses an authcode file located in the users HOME directory ($HOME/.authcode) instead of a local one .authcode file in the git directory. It seemed more convenient at the time. Minor drawback: lack of multi-audible-account support.

Signed-off-by: Me <corbolais@gmail.com>