### PR TITLE
Fixed HOME environment variable missing under Windows

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -6,7 +6,7 @@ codec=libmp3lame
 extension=mp3
 mode=chaptered
 authcode=".authcode";
-authcodeDirs="${HOME}/ ./";
+if [ -z ${HOME+x} ] && ! [ -z ${USERPROFILE+x} ]; then HOME="$USERPROFILE"; fi
 GREP=$(grep --version | grep -q GNU && echo "grep" || echo "ggrep")
 
 if ! [[ $(type -P "$GREP") ]]; then

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -8,7 +8,6 @@ mode=chaptered
 authcode=".authcode";
 if [ -z ${HOME+x} ] && ! [ -z ${USERPROFILE+x} ]; then HOME="$USERPROFILE"; fi
 authcodeDirs="${HOME}/ ./"
-
 GREP=$(grep --version | grep -q GNU && echo "grep" || echo "ggrep")
 
 if ! [[ $(type -P "$GREP") ]]; then

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -7,6 +7,8 @@ extension=mp3
 mode=chaptered
 authcode=".authcode";
 if [ -z ${HOME+x} ] && ! [ -z ${USERPROFILE+x} ]; then HOME="$USERPROFILE"; fi
+authcodeDirs="${HOME}/ ./"
+
 GREP=$(grep --version | grep -q GNU && echo "grep" || echo "ggrep")
 
 if ! [[ $(type -P "$GREP") ]]; then


### PR DESCRIPTION
The HOME environment variable is not set on Windows by default. Instead Windows uses USERPROFILE. It is possible for HOME to be set on Windows but for users who have not done this they will get: `HOME: unbound variable`. I have added a line that sets HOME to USERPROFILE if HOME is missing and USERPROFILE is found. This solves the unbound variable error.

I've tested this on Windows 10 using MinGW 6.2 - works perfectly other than the MAX_PATH on windows is much shorter than on other OS's meaning the output audio file tends to have a path that is too long: `$(dirname "${path}")/${genre}/${artist}/${title}/${title}.${extension}` The title is sometimes egregiously long on some audio-books.