### PR TITLE
AAXtoMP3: fix possition of dash when replacing colon

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -107,7 +107,7 @@ do
     save_metadata "${path}"
     genre=$(get_metadata_value genre)
     artist=$(get_metadata_value artist)
-    title=$(get_metadata_value title | sed 's/'\:'/'-\ '/g' | xargs -0)
+    title=$(get_metadata_value title | sed 's/'\:'/'\ -'/g' | xargs -0)
     output_directory="$(dirname "${path}")/${genre}/${artist}/${title}"
     mkdir -p "${output_directory}"
     full_file_path="${output_directory}/${title}.${extension}"


### PR DESCRIPTION
Have no clue if this is a bug or just with the audio-book, I'm currently decoding but I got some strangely misplaced dashes. This commit fixed the problem. please reject if it was a one-time issue.