### PR TITLE
make ~/.authcode work correctly

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -58,6 +58,8 @@ for dir in $authcodeDirs; do
 	if [ ! -f "$codeFile" -o ! -s "$codeFile" ]; then
 		codeFile=""
 		echo "INFO: Sorry, missing or empty \"$codeFile\" found, skipping.";
+	else
+		break
 	fi;
 done;
 


### PR DESCRIPTION
fixes #60

the issue was that the check for './.authcode' overwrote the results of any successful check to '~/.authcode'