### PR TITLE
Add bc to Ubuntu package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ __Note:__ At least one of the above must be exist. The code must also match the 
 __Ubuntu, Linux Mint, Debian__
 ```
 sudo apt-get update
-sudo apt-get install ffmpeg libav-tools x264 x265
+sudo apt-get install ffmpeg libav-tools x264 x265 bc
 ```
 
 __Fedora__


### PR DESCRIPTION
On a stock Ubuntu 16.04 server install, bc is not present, and splitting into chapter files fails.