### PR TITLE
Add alternative method to get authentication code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [-c|--chaptered] [
 You will need your authentication code that comes from Audible's servers. This 
 will be used by ffmpeg to perform the initial audio convert. You can obtain 
 this string from a tool like 
-[audible-activator](https://github.com/inAudible-NG/audible-activator).
+[audible-activator](https://github.com/inAudible-NG/audible-activator) or [inAudible-NG tables](https://github.com/inAudible-NG/tables).
 
 #### Specifying the AUTHCODE.
 In order of __precidence__.


### PR DESCRIPTION
Link to the RainbowCrack plugin which lets you recover your own Audible activation data (activation_bytes) offline.