### PR TITLE
Fix opus file extension and container format

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -28,7 +28,7 @@ while true; do
                       # Apple m4a music format.
     -a | --aac        ) codec=copy; extension=m4a; mode=single; container=m4a;          shift ;;        
                       # Ogg Format
-    -o | --opus       ) codec=libopus; extension=ogg; container=flac;                   shift ;;        
+    -o | --opus       ) codec=libopus; extension=opus; container=ogg;                    shift ;;        
                       # If appropriate use only a single file output.
     -s | --single     ) mode=single;                                                    shift ;;        
                       # If appropriate use only a single file output.

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -28,7 +28,7 @@ while true; do
                       # Apple m4a music format.
     -a | --aac        ) codec=copy; extension=m4a; mode=single; container=m4a;          shift ;;        
                       # Ogg Format
-    -o | --opus       ) codec=libopus; extension=opus; container=ogg;                    shift ;;        
+    -o | --opus       ) codec=libopus; extension=opus; container=ogg;                   shift ;;        
                       # If appropriate use only a single file output.
     -s | --single     ) mode=single;                                                    shift ;;        
                       # If appropriate use only a single file output.


### PR DESCRIPTION
Opus file extension should be .opus according to the RFC https://tools.ietf.org/html/rfc7845#section-9 
(and container format should be ogg instead of flac just for correctness' sake - although that is never used in this script)