### PR TITLE
Fix mkdir: cannot create directory : File name too long 

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -351,6 +351,7 @@ do
   genre=$(get_metadata_value genre)
   artist=$(get_metadata_value artist)
   title=$(get_metadata_value title | $SED 's/'\:'/'-'/g' | $SED 's/- /-/g' | xargs -0)
+  title=${title:0:100}
   if [ "x${targetdir}" != "x" ] ; then
     output_directory="${targetdir}/${genre}/${artist}/${title}"
   else


### PR DESCRIPTION
On linux, file name max length is 143 characters. I put a limit to title file name as a fix max name to 100 characters to avoid error and process abortion