### PR TITLE
Small updates for Opus and metadata

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -29,7 +29,7 @@ while true; do
                       # Apple m4a music format.
     -a | --aac        ) codec=copy; extension=m4a; mode=single; container=m4a;          shift ;;
                       # Ogg Format
-    -o | --opus       ) codec=libopus; extension=ogg; container=flac;                   shift ;;
+    -o | --opus       ) codec=libopus; extension=opus; container=ogg;                   shift ;;
                       # If appropriate use only a single file output.
     -s | --single     ) mode=single;                                                    shift ;;
                       # If appropriate use only a single file output.
@@ -384,7 +384,7 @@ do
   # This is the main work horse command.  This is the primary transcoder.
   # This is the primary transcode. All the heavy lifting is here.
   debug 'ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" "${output_file}"'
-  </dev/null ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" "${output_file}"
+  </dev/null ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" -f ${container} "${output_file}"
 
   log "Created ${output_file}."
   # -----
@@ -437,7 +437,8 @@ do
         log "Spliting chapter ${chapternum} start:${chapter_start%?}(s) end:${chapter_end}(s)"
         </dev/null ffmpeg -loglevel quiet -nostats -i "${output_file}" -i "${cover_file}" -ss "${chapter_start%?}" -to "${chapter_end}" -map 0:0 -map 1:0 -acodec "${codec}" ${id3_version_param} \
         -metadata:s:v title="Album cover" -metadata:s:v comment="Cover (Front)" -metadata track="${chapternum}" -metadata title="${chapter_title}" \
-        "${chapter_file}"
+        -metadata:s:a title="${chapter_title}" -metadata:s:a track="${chapternum}" \
+        -f ${container} "${chapter_file}"
 
         # -----
         # OK lets get what need for the next chapter in the Playlist m3u file.


### PR DESCRIPTION
Forcibly add the track and title metadata to the audio stream.  Fixes missing meta-data with Plex and possibly other programs.

Use the .opus file extension and ogg container for opus files to match recommended practice, and correct detection of opus files in Plex and other programs