### PR TITLE
Remove chapter metadata in "chaptered mode"

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -437,7 +437,7 @@ do
         log "Splitting chapter ${chapternum} start:${chapter_start%?}(s) end:${chapter_end}(s)"
         </dev/null ffmpeg -loglevel quiet -nostats -i "${output_file}" -i "${cover_file}" -ss "${chapter_start%?}" -to "${chapter_end}" -map 0:0 -map 1:0 -acodec "${codec}" ${id3_version_param} \
         -metadata:s:v title="Album cover" -metadata:s:v comment="Cover (Front)" -metadata track="${chapternum}" -metadata title="${chapter_title}" \
-        -metadata:s:a title="${chapter_title}" -metadata:s:a track="${chapternum}" \
+        -metadata:s:a title="${chapter_title}" -metadata:s:a track="${chapternum}" -map_chapters -1 \
         -f ${container} "${chapter_file}"
 
         # -----


### PR DESCRIPTION
As I mentioned in #127 the app I use has problems, if the chaptered files still hold menu metadata.
I'm not very experienced in this area but for me this menu metadata is not useful, if I have chaptered files.

So this PR removes the menu metadata from the chaptered files. Let me know if this has some unwanted side effects, but my tests with `-e:m4b -c`worked for me.