### PR TITLE
Continue after interruption

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,7 +5,7 @@
 # Command Line Options
 
 # Usage Synopsis.
-usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--chaptered]\n[-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n{FILES}\n'
+usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--chaptered]\n[-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>]{FILES}\n'
 codec=libmp3lame            # Default encoder.
 extension=mp3               # Default encoder extension.
 mode=chaptered              # Multi file output
@@ -16,6 +16,8 @@ container=mp3               # Just in case we need to change the container.  Use
 VALIDATE=0                  # Validate the input aax file(s) only.  No Transcoding of files will occur
 DEBUG=0                     # Default off, If set extremely verbose output.
 noclobber=0                 # Default off, clobber only if flag is enabled
+continue=0                  # Default off, If set Transcoding is skiped and chapter splitting starts at chapter continueAt.
+continueAt=1                # Optional chapter to continue splitting the chapters.
 
 # -----
 # Code tip Do not have any script above this point that calls a function or a binary.  If you do
@@ -52,6 +54,8 @@ while true; do
     -d | --debug      ) DEBUG=1;                                                        shift ;;
                       # Validate ONLY the aax file(s) No transcoding occurs
     -V | --validate   ) VALIDATE=1;                                                     shift ;;
+                      # continue spliting chapters at chapter continueAt
+    --continue        ) continueAt="$2"; continue=1;                                    shift 2 ;;
                       # Command synopsis.
     -h | --help       ) printf "$usage" $0 ;                                            exit ;;
                       # Standard flag signifying the end of command line processing.
@@ -381,19 +385,21 @@ do
   debug_vars "Book and Variable values" title auth_code mode aax_file container codec bitrate artist album_artist album album_date genre copyright output_file metadata_file working_directory
 
   # -----
-  # This is the main work horse command.  This is the primary transcoder.
-  # This is the primary transcode. All the heavy lifting is here.
-  debug 'ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" "${output_file}"'
-  </dev/null ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" -f ${container} "${output_file}"
+  if [ "${continue}" == "0" ]; then
+    # This is the main work horse command.  This is the primary transcoder.
+    # This is the primary transcode. All the heavy lifting is here.
+    debug 'ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" "${output_file}"'
+    </dev/null ffmpeg -loglevel error -stats -activation_bytes "${auth_code}" -i "${aax_file}" -vn -codec:a "${codec}" -ab ${bitrate} -map_metadata -1 -metadata title="${title}" -metadata artist="${artist}" -metadata album_artist="${album_artist}" -metadata album="${album}" -metadata date="${album_date}" -metadata track="1/1" -metadata genre="${genre}" -metadata copyright="${copyright}" -f ${container} "${output_file}"
 
-  log "Created ${output_file}."
-  # -----
-
+    log "Created ${output_file}."
+    # -----
+  fi
   # Grab the cover art if available.
   cover_file="${output_directory}/cover.jpg"
-  log "Extracting cover into ${cover_file}..."
-  </dev/null ffmpeg -loglevel error -activation_bytes "${auth_code}" -i "${aax_file}" -an -codec:v copy "${cover_file}"
-
+  if [ "${continue}" == "0" ]; then
+    log "Extracting cover into ${cover_file}..."
+    </dev/null ffmpeg -loglevel error -activation_bytes "${auth_code}" -i "${aax_file}" -an -codec:v copy "${cover_file}"
+  fi
   # -----
   # OK now spit the file if that's what you want.
   # If we want multiple file we take the big mp3 and split it by chapter.
@@ -402,13 +408,17 @@ do
   if [ "${mode}" == "chaptered" ]; then
     # Playlist m3u support
     playlist_file="${output_directory}/${title}.m3u"
-    log "Creating PlayList ${title}.m3u"
-    echo '#EXTM3U' > "${playlist_file}"
+    if [ "${continue}" == "0" ]; then
+      log "Creating PlayList ${title}.m3u"
+      echo '#EXTM3U' > "${playlist_file}"
+    fi
 
     # Determine the number of chapters.
     chaptercount=$($GREP -Pc "Chapter.*start.*end" $metadata_file)
     log "Extracting ${chaptercount} chapter files from ${output_file}..."
-
+    if [ "${continue}" == "1" ]; then
+      log "Continuing at chapter ${continueAt}:"
+    fi
     chapternum=1
     while read -r -u9 first _ _ chapter_start _ chapter_end
     do
@@ -431,21 +441,21 @@ do
 
         # Big Long chapter debug
         debug_vars "Chapter Variables:" cover_file chapter_start chapter_end id3_version_param chapternum chapter_title chapter_file
-
-        # Extract chapter by time stamps start and finish of chapter.
-        # This extracts based on time stamps start and end.
-        log "Splitting chapter ${chapternum}/${chaptercount} start:${chapter_start%?}(s) end:${chapter_end}(s)"
-        </dev/null ffmpeg -loglevel quiet -nostats -i "${output_file}" -i "${cover_file}" -ss "${chapter_start%?}" -to "${chapter_end}" -map 0:0 -map 1:0 -acodec "${codec}" ${id3_version_param} \
-        -metadata:s:v title="Album cover" -metadata:s:v comment="Cover (Front)" -metadata track="${chapternum}" -metadata title="${chapter_title}" \
-        -metadata:s:a title="${chapter_title}" -metadata:s:a track="${chapternum}" -map_chapters -1 \
-        -f ${container} "${chapter_file}"
-
-        # -----
-        # OK lets get what need for the next chapter in the Playlist m3u file.
-        # Playlist creation.
-        duration=$(echo "${chapter_end} - ${chapter_start%?}" | bc)
-        echo "#EXTINF:${duration%.*},${title} - ${chapter}" >>  "${playlist_file}"
-        echo "${chapter_title}.${extension}" >> "${playlist_file}"
+        if [ "$((${continueAt} > ${chapternum}))" = "0" ]; then
+          # Extract chapter by time stamps start and finish of chapter.
+          # This extracts based on time stamps start and end.
+          log "Splitting chapter ${chapternum}/${chaptercount} start:${chapter_start%?}(s) end:${chapter_end}(s)"
+          </dev/null ffmpeg -loglevel quiet -nostats -i "${output_file}" -i "${cover_file}" -ss "${chapter_start%?}" -to "${chapter_end}" -map 0:0 -map 1:0 -acodec "${codec}" ${id3_version_param} \
+          -metadata:s:v title="Album cover" -metadata:s:v comment="Cover (Front)" -metadata track="${chapternum}" -metadata title="${chapter_title}" \
+          -metadata:s:a title="${chapter_title}" -metadata:s:a track="${chapternum}" -map_chapters -1 \
+          -f ${container} "${chapter_file}"
+          # -----
+          # OK lets get what need for the next chapter in the Playlist m3u file.
+          # Playlist creation.
+          duration=$(echo "${chapter_end} - ${chapter_start%?}" | bc)
+          echo "#EXTINF:${duration%.*},${title} - ${chapter}" >>  "${playlist_file}"
+          echo "${chapter_title}.${extension}" >> "${playlist_file}"
+        fi
         chapternum=$((chapternum + 1 ))
 
         # ----

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Thanks to kbabioch, this script has also been packaged in the [AUR](https://aur.
 
 ## Usage(s)
 ```
-bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [-d|--debug] [-h|--help] <AAX INPUT_FILES>...
+bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [-d|--debug] [-h|--help] [--continue <CHAPTERNUMBER>] <AAX INPUT_FILES>...
 ```
 
 * **&lt;AAX INPUT_FILES&gt;**... are considered input file(s), useful for batching!
@@ -48,6 +48,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [-c|--chaptered] [
 * **-e:m4b**         Create a m4b audio file. This is the book version of the m4a format.
 * **-s** or **--single**    Output a single file for the entire book. If you only want a single ogg file for instance.
 * **-c** or **--chaptered** Output a single file per chapter. The `--chaptered` will only work if it follows the `--aac -e:m4a -e:m4b` options.
+* **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process get interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 
 
 ### [AUTHCODE]


### PR DESCRIPTION
Until now, when the conversion of a audiobook gets interrrupted during the splitting phase, one has to delete all the output files and restart from beginning.
This can be very uncomfy, especially if it's a long audiobook and the computer did work on it for several hours.
I added some changes, so that one only has to delete the last (incompletely generated) chapter and add "--continue " to the command where CHAPTERNUMBER is the chapter, that has been interrupted while splitting of.
For this to work I mainly just skipped the steps which were already done before interruption with if-conditions.