### PR TITLE
Added compression levels for mp3, opus and flac

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -553,6 +553,7 @@ do
             -map 0:0 \
             -map 1:0 \
             -acodec "${codec}" ${id3_version_param} \
+            ${compression_level_param} \
             -metadata:s:v title="Album cover" \
             -metadata:s:v comment="Cover (Front)" \
             -metadata track="${chapternum}" \

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -446,7 +446,7 @@ do
     compression_level_param="-compression_level ${level}"
   fi
   
-  # -----  
+  # -----
   if [ "${continue}" == "0" ]; then
     # This is the main work horse command.  This is the primary transcoder.
     # This is the primary transcode. All the heavy lifting is here.

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,9 +5,10 @@
 # Command Line Options
 
 # Usage Synopsis.
-usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--chaptered]\n[-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>]{FILES}\n'
+usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>]{FILES}\n'
 codec=libmp3lame            # Default encoder.
 extension=mp3               # Default encoder extension.
+level=-1                    # Compression level. Can be given for mp3, flac and opus. -1 = default/not specified.
 mode=chaptered              # Multi file output
 auth_code=                  # Required to be set via file or option.
 targetdir=                  # Optional output location.  Note default is basedir of AAX file.
@@ -56,6 +57,8 @@ while true; do
     -V | --validate   ) VALIDATE=1;                                                     shift ;;
                       # continue splitting chapters at chapter continueAt
     --continue        ) continueAt="$2"; continue=1;                                    shift 2 ;;
+                      # Compression level
+    --level           ) level="$2";                                                     shift 2 ;;
                       # Command synopsis.
     -h | --help       ) printf "$usage" $0 ;                                            exit ;;
                       # Standard flag signifying the end of command line processing.
@@ -264,6 +267,34 @@ if [[ "x${completedir}" != "x"  ]]; then
 fi
 
 # -----
+# If a compression level is given, check whether the given codec supports compression level specifiers and whether the level is valid.
+if [ "${level}" != "-1" ]; then
+  if [ "${codec}" == "flac" ]; then
+    if [ "$((${level} < 0 || ${level} > 12 ))" = "1" ]; then
+      echo "ERROR Flac compression level has to be in the range from 0 to 12!"
+      echo "$usage"
+      exit 1
+    fi
+  elif [ "${codec}" == "libopus" ]; then
+    if [ "$((${level} < 0 || ${level} > 10 ))" = "1" ]; then
+      echo "ERROR Opus compression level has to be in the range from 0 to 10!"
+      echo "$usage"
+      exit 1
+    fi
+  elif [ "${codec}" == "libmp3lame" ]; then
+    if [ "$((${level} < 0 || ${level} > 9 ))" = "1" ]; then
+      echo "ERROR MP3 compression level has to be in the range from 0 to 9!"
+      echo "$usage"
+      exit 1
+    fi
+  else
+    echo "ERROR This codec doesnt support compression levels!"
+    echo "$usage"
+    exit 1
+  fi
+fi
+
+# -----
 # Clean up if someone hits ^c or the script exits for any reason.
 trap 'rm -r -f "${working_directory}"' EXIT
 
@@ -409,7 +440,13 @@ do
   # and coders wanting to extend the script.
   debug_vars "Book and Variable values" title auth_code mode aax_file container codec bitrate artist album_artist album album_date genre copyright narrator description output_file metadata_file working_directory
 
-  # -----
+  # If level != -1 specify a compression level in ffmpeg.
+  compression_level_param=""
+  if [ "${level}" != "-1" ]; then
+    compression_level_param="-compression_level ${level}"
+  fi
+  
+  # -----  
   if [ "${continue}" == "0" ]; then
     # This is the main work horse command.  This is the primary transcoder.
     # This is the primary transcode. All the heavy lifting is here.
@@ -420,6 +457,7 @@ do
       -i "${aax_file}" \
       -vn \
       -codec:a "${codec}" \
+      ${compression_level_param} \
       -ab ${bitrate} \
       -map_metadata -1 \
       -metadata title="${title}" \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Audible fails for some reason.
 * grep Some OS distributions do not have it installed.
 * sed Some OS versions will need to install gnu sed.
 * mp4art used to add cover art to m4a and m4b files. Optional
-* mediainfo used to add additional media tags like narrator. Optional
 
 ## OSX
 Thanks to thibaudcolas, this script has been tested on OSX 10.11.6 El Capitan. YMMV, but it should work for 
@@ -30,7 +29,7 @@ Thanks to kbabioch, this script has also been packaged in the [AUR](https://aur.
 
 ## Usage(s)
 ```
-bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [-d|--debug] [-h|--help] [--continue <CHAPTERNUMBER>] <AAX INPUT_FILES>...
+bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESSIONLEVEL>] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [-d|--debug] [-h|--help] [--continue <CHAPTERNUMBER>] <AAX INPUT_FILES>...
 ```
 
 * **&lt;AAX INPUT_FILES&gt;**... are considered input file(s), useful for batching!
@@ -50,6 +49,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [-c|--chaptered] [
 * **-s** or **--single**    Output a single file for the entire book. If you only want a single ogg file for instance.
 * **-c** or **--chaptered** Output a single file per chapter. The `--chaptered` will only work if it follows the `--aac -e:m4a -e:m4b --flac` options.
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
+* **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
 
 
 ### [AUTHCODE]
@@ -74,11 +74,13 @@ __Note:__ At least one of the above must be exist. The code must also match the 
 * The default mode is **chaptered**
 * If you want a mp3 file per chapter do not use the **--single** option. 
 * A m3u playlist file will also be created in this instance in the case of **default** chaptered output.
+* **--level** has to be in range 0-9, where 9 is fastest and 0 is highest quality.
 
 ### Ogg/Opus Encoding
 * Can be done by using the **-o** or **--opus** command line switches
 * The default mode is **chaptered**
 * Opus coded files are stored in the ogg container format for better compatibility.
+* **--level** has to be in range 0-10, where 0 is fastest and 10 is highest quality.
 
 ### AAC Encoding
 * Can be done by using the **-a** or **--aac** command line switches
@@ -92,6 +94,7 @@ __Note:__ At least one of the above must be exist. The code must also match the 
 * The default mode is **single**
 * FLAC is an open format with royalty-free licensing
 * This will only produce 1 audio file as output. If you want a flac file per chapter do use **-c** or **--chaptered**.
+* **--level** has to be in range 0-12, where 0 is fastest and 12 is highest compression.
 
 ### M4A and M4B Containers
 * These containers were created by Apple Inc. They were meant to be the successor to mp3.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Audible fails for some reason.
 * grep Some OS distributions do not have it installed.
 * sed Some OS versions will need to install gnu sed.
 * mp4art used to add cover art to m4a and m4b files. Optional
+* mediainfo used to add additional media tags like narrator. Optional
 
 ## OSX
 Thanks to thibaudcolas, this script has been tested on OSX 10.11.6 El Capitan. YMMV, but it should work for 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ __Note:__ At least one of the above must be exist. The code must also match the 
 * The default mode is **chaptered**
 * If you want a mp3 file per chapter do not use the **--single** option. 
 * A m3u playlist file will also be created in this instance in the case of **default** chaptered output.
-* **--level** has to be in range 0-9, where 9 is fastest and 0 is highest quality.
+* **--level** has to be in range 0-9, where 9 is fastest and 0 is highest quality. Please note: The quality can **never** become higher than the qualitiy of the original aax file!
 
 ### Ogg/Opus Encoding
 * Can be done by using the **-o** or **--opus** command line switches
 * The default mode is **chaptered**
 * Opus coded files are stored in the ogg container format for better compatibility.
-* **--level** has to be in range 0-10, where 0 is fastest and 10 is highest quality.
+* **--level** has to be in range 0-10, where 0 is fastest and 10 is highest quality. Please note: The quality can **never** become higher than the qualitiy of the original aax file!
 
 ### AAC Encoding
 * Can be done by using the **-a** or **--aac** command line switches
@@ -95,7 +95,7 @@ __Note:__ At least one of the above must be exist. The code must also match the 
 * The default mode is **single**
 * FLAC is an open format with royalty-free licensing
 * This will only produce 1 audio file as output. If you want a flac file per chapter do use **-c** or **--chaptered**.
-* **--level** has to be in range 0-12, where 0 is fastest and 12 is highest compression.
+* **--level** has to be in range 0-12, where 0 is fastest and 12 is highest compression. Since flac is lossless, the quality always remains the same.
 
 ### M4A and M4B Containers
 * These containers were created by Apple Inc. They were meant to be the successor to mp3.


### PR DESCRIPTION
As written in the headline I added compression levels for mp3, opus and flac.
`--level <COMPRESSIONLEVEL>`
mp3: 0-9 where 0 is highest quality
opus: 0-10 where 10 is highest quality
flac: 0-12 where 12 is highest compression
Invalid values or applying level to other codecs results in an error message.