### PR TITLE
Exit if no aax file is found

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -281,7 +281,7 @@ validate_aax() {
   # Test for existence
   if [[ ! -r "${media_file}" ]] ; then
     log "ERROR File NOT Found: ${media_file}"
-    return
+    return 1
   else
     if [[ "${VALIDATE}" == "1" ]]; then
       log "Test 1 SUCCESS: ${media_file}"


### PR DESCRIPTION
If we just use `return` and the file `$media_file` (the aax file) is not readable, the script continues until an error.
Instead we `return 1` so `errexit` takes care of quitting