### PR TITLE
Author customization

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -417,15 +417,17 @@ do
   save_metadata "${aax_file}"
   genre=$(get_metadata_value genre)
   if [ "x${authorOverride}" != "x" ]; then
-    #Override
+    #Manual Override
     artist="${authorOverride}"
     album_artist="${authorOverride}"
   else
     if [ "${keepArtist}" != "-1" ]; then
-      #                                                                 sed command: 'C. S. Lewis' -> 'C.S. Lewis'
-      artist=$(get_metadata_value artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')
-      album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')"
+      # Choose artist from the one that are present in the metadata. Comma separated list of names
+      #                                                                 remove leading space;     'C. S. Lewis' -> 'C.S. Lewis'
+      artist="$(get_metadata_value artist | cut -d',' -f"$keepArtist" | $SED -E 's|^ ||g; s|\. +|\.|g; s|((\w+\.)+)|\1 |g')"
+      album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|^ ||g; s|\. +|\.|g; s|((\w+\.)+)|\1 |g')"
     else
+      # The default
       artist=$(get_metadata_value artist)
       album_artist="$(get_metadata_value album_artist)"
     fi

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,7 +5,7 @@
 # Command Line Options
 
 # Usage Synopsis.
-usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>]{FILES}\n'
+usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>] [--keep-artist <N>] {FILES}\n'
 codec=libmp3lame            # Default encoder.
 extension=mp3               # Default encoder extension.
 level=-1                    # Compression level. Can be given for mp3, flac and opus. -1 = default/not specified.
@@ -19,6 +19,7 @@ DEBUG=0                     # Default off, If set extremely verbose output.
 noclobber=0                 # Default off, clobber only if flag is enabled
 continue=0                  # Default off, If set Transcoding is skipped and chapter splitting starts at chapter continueAt.
 continueAt=1                # Optional chapter to continue splitting the chapters.
+keepArtist=-1               # Default off, if set change artist metadata to use the passed argument as field
 
 # -----
 # Code tip Do not have any script above this point that calls a function or a binary.  If you do
@@ -59,6 +60,8 @@ while true; do
     --continue        ) continueAt="$2"; continue=1;                                    shift 2 ;;
                       # Compression level
     --level           ) level="$2";                                                     shift 2 ;;
+                      # Keep artist number n
+    --keep-artist     ) keepArtist="$2";                                                shift 2 ;;
                       # Command synopsis.
     -h | --help       ) printf "$usage" $0 ;                                            exit ;;
                       # Standard flag signifying the end of command line processing.
@@ -410,7 +413,14 @@ do
   # Make sure everything is a variable.  Simplifying Command interpretation
   save_metadata "${aax_file}"
   genre=$(get_metadata_value genre)
-  artist=$(get_metadata_value artist)
+  if [ "${keepArtist}" != "-1" ]; then
+    #                                                                 sed command: 'C. S. Lewis' -> 'C.S. Lewis'
+    artist=$(get_metadata_value artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')
+    album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)')"
+  else
+    artist=$(get_metadata_value artist)
+    album_artist="$(get_metadata_value album_artist)"
+  fi
   title=$(get_metadata_value title | $SED 's/'\:'/'-'/g' | $SED 's/- /-/g' | xargs -0)
   title=${title:0:100}
   if [ "x${targetdir}" != "x" ] ; then
@@ -420,7 +430,6 @@ do
   fi
   output_file="${output_directory}/${title}.${extension}"
   bitrate="$(get_bitrate)k"
-  album_artist="$(get_metadata_value album_artist)"
   album="$(get_metadata_value album)"
   album_date="$(get_metadata_value date)"
   copyright="$(get_metadata_value copyright)"

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,7 +5,7 @@
 # Command Line Options
 
 # Usage Synopsis.
-usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>] [--keep-artist <N>] {FILES}\n'
+usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>] [--keep-artist <N>] [--author <AUTHOR>] {FILES}\n'
 codec=libmp3lame            # Default encoder.
 extension=mp3               # Default encoder extension.
 level=-1                    # Compression level. Can be given for mp3, flac and opus. -1 = default/not specified.
@@ -20,6 +20,7 @@ noclobber=0                 # Default off, clobber only if flag is enabled
 continue=0                  # Default off, If set Transcoding is skipped and chapter splitting starts at chapter continueAt.
 continueAt=1                # Optional chapter to continue splitting the chapters.
 keepArtist=-1               # Default off, if set change artist metadata to use the passed argument as field
+authorOverride=             # Override the author, ignoring the metadata           
 
 # -----
 # Code tip Do not have any script above this point that calls a function or a binary.  If you do
@@ -62,6 +63,8 @@ while true; do
     --level           ) level="$2";                                                     shift 2 ;;
                       # Keep artist number n
     --keep-artist     ) keepArtist="$2";                                                shift 2 ;;
+                      # Author override
+    --author          ) authorOverride="$2";                                            shift 2 ;;
                       # Command synopsis.
     -h | --help       ) printf "$usage" $0 ;                                            exit ;;
                       # Standard flag signifying the end of command line processing.
@@ -144,7 +147,7 @@ log() {
 
 # -----
 # Print out what we have already after command line processing.
-debug_vars "Command line options as set" codec extension mode container targetdir completedir auth_code
+debug_vars "Command line options as set" codec extension mode container targetdir completedir auth_code keepArtist authorOverride
 
 # ========================================================================
 # Variable validation
@@ -413,13 +416,19 @@ do
   # Make sure everything is a variable.  Simplifying Command interpretation
   save_metadata "${aax_file}"
   genre=$(get_metadata_value genre)
-  if [ "${keepArtist}" != "-1" ]; then
-    #                                                                 sed command: 'C. S. Lewis' -> 'C.S. Lewis'
-    artist=$(get_metadata_value artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')
-    album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')"
+  if [ "x${authorOverride}" != "x" ]; then
+    #Override
+    artist="${authorOverride}"
+    album_artist="${authorOverride}"
   else
-    artist=$(get_metadata_value artist)
-    album_artist="$(get_metadata_value album_artist)"
+    if [ "${keepArtist}" != "-1" ]; then
+      #                                                                 sed command: 'C. S. Lewis' -> 'C.S. Lewis'
+      artist=$(get_metadata_value artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')
+      album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')"
+    else
+      artist=$(get_metadata_value artist)
+      album_artist="$(get_metadata_value album_artist)"
+    fi
   fi
   title=$(get_metadata_value title | $SED 's/'\:'/'-'/g' | $SED 's/- /-/g' | xargs -0)
   title=${title:0:100}

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -5,7 +5,7 @@
 # Command Line Options
 
 # Usage Synopsis.
-usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>] [--keep-artist <N>] [--author <AUTHOR>] {FILES}\n'
+usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]\n[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]\n[--target_dir <PATH>] [--complete_dir <PATH>] [--validate]\n[--continue <CHAPTERNUMBER>] [--keep-author <N>] [--author <AUTHOR>] {FILES}\n'
 codec=libmp3lame            # Default encoder.
 extension=mp3               # Default encoder extension.
 level=-1                    # Compression level. Can be given for mp3, flac and opus. -1 = default/not specified.
@@ -19,7 +19,7 @@ DEBUG=0                     # Default off, If set extremely verbose output.
 noclobber=0                 # Default off, clobber only if flag is enabled
 continue=0                  # Default off, If set Transcoding is skipped and chapter splitting starts at chapter continueAt.
 continueAt=1                # Optional chapter to continue splitting the chapters.
-keepArtist=-1               # Default off, if set change artist metadata to use the passed argument as field
+keepArtist=-1               # Default off, if set change author metadata to use the passed argument as field
 authorOverride=             # Override the author, ignoring the metadata           
 
 # -----
@@ -61,8 +61,8 @@ while true; do
     --continue        ) continueAt="$2"; continue=1;                                    shift 2 ;;
                       # Compression level
     --level           ) level="$2";                                                     shift 2 ;;
-                      # Keep artist number n
-    --keep-artist     ) keepArtist="$2";                                                shift 2 ;;
+                      # Keep author number n
+    --keep-author     ) keepArtist="$2";                                                shift 2 ;;
                       # Author override
     --author          ) authorOverride="$2";                                            shift 2 ;;
                       # Command synopsis.

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -416,7 +416,7 @@ do
   if [ "${keepArtist}" != "-1" ]; then
     #                                                                 sed command: 'C. S. Lewis' -> 'C.S. Lewis'
     artist=$(get_metadata_value artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')
-    album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)')"
+    album_artist="$(get_metadata_value album_artist | cut -d',' -f"$keepArtist" | $SED -E 's|\. +|\.|g; s|((\w+\.)+)|\1 |g')"
   else
     artist=$(get_metadata_value artist)
     album_artist="$(get_metadata_value album_artist)"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESS
 * **-c** or **--chaptered** Output a single file per chapter. The `--chaptered` will only work if it follows the `--aac -e:m4a -e:m4b --flac` options.
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 * **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
+* **--keep-artist &lt;FIELD&gt;**           In case you don't want to keep all the authors in the metadata, with this flag you can specify a specific field (1 is the first, 2 is the second...)
 
 
 ### [AUTHCODE]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESS
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 * **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
 * **--keep-author &lt;FIELD&gt;**           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
-* **--author &lt;AUTHOR&gt;**               Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (eg. spacing, accents..)
+* **--author &lt;AUTHOR&gt;**               Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (eg. spacing, accents..). Has precedence over `--keep-author`.
 
 
 ### [AUTHCODE]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESS
 * **-c** or **--chaptered** Output a single file per chapter. The `--chaptered` will only work if it follows the `--aac -e:m4a -e:m4b --flac` options.
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 * **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
-* **--keep-artist &lt;FIELD&gt;**           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
+* **--keep-author &lt;FIELD&gt;**           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
 * **--author &lt;AUTHOR&gt;**               Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (eg. spacing, accents..)
 
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESS
 * **-c** or **--chaptered** Output a single file per chapter. The `--chaptered` will only work if it follows the `--aac -e:m4a -e:m4b --flac` options.
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 * **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
-* **--keep-artist &lt;FIELD&gt;**           In case you don't want to keep all the authors in the metadata, with this flag you can specify a specific field (1 is the first, 2 is the second...)
+* **--keep-artist &lt;FIELD&gt;**           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
 
 
 ### [AUTHCODE]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESS
 * **-l** or **--loglevel &lt;LOGLEVEL&gt;** Set loglevel: 0 = progress only, 1 (default) = more information, output of chapter splitting progress is limitted to a progressbar, 2 = more information, especially on chapter splitting, 3 = debug mode
 
 
-
 ### [AUTHCODE]
 **Your** Audible auth code (it won't correctly decode otherwise) (required).
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESS
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 * **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
 * **--keep-artist &lt;FIELD&gt;**           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
+* **--author &lt;AUTHOR&gt;**               Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (eg. spacing, accents..)
 
 
 ### [AUTHCODE]


### PR DESCRIPTION
Two additional flags for customizing author metadata

* `--keep-author`:           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
* `--author`:                    Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (eg. spacing, accents..). Has precedence over `--keep-author`.