### PR TITLE
Call AAXtoMP3 interactively

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -684,7 +684,7 @@ do
         #ffmpeg version 4+ and on the output for all older versions.
         split_input=""
         split_output=""
-        if [ "$(($(ffmpeg -version | sed -E 's/[^0-9]*([0-9]).*/\1/g;1q') > 3))" = "1" ]; then
+        if [ "$(($(ffmpeg -version | $SED -E 's/[^0-9]*([0-9]).*/\1/g;1q') > 3))" = "1" ]; then
           split_input="-ss ${chapter_start%?} -to ${chapter_end}"
         else
           split_output="-ss ${chapter_start%?} -to ${chapter_end}"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Thanks to kbabioch, this script has also been packaged in the [AUR](https://aur.
 ```
 bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|-aac] [-s|--single] [--level <COMPRESSIONLEVEL>] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [-d|--debug] [-h|--help] [--continue <CHAPTERNUMBER>] <AAX INPUT_FILES>...
 ```
+or if you want to get guided through the options
+```
+bash interactiveAAXtoMP3 [-a|--advanced] [-h|--help]
+```
 
 * **&lt;AAX INPUT_FILES&gt;**... are considered input file(s), useful for batching!
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bash interactiveAAXtoMP3 [-a|--advanced] [-h|--help]
 
 * **&lt;AAX INPUT_FILES&gt;**... are considered input file(s), useful for batching!
 
-## Options
+## Options for AAXtoMP3
 * **-f** or **--flac**   Flac Encoding and as default produces a single file.
 * **-o** or **--opus**   Ogg/Opus Encoding defaults to multiple file output by chapter. The extension is .ogg
 * **-a** or **--aac**    AAC Encoding and produce a m4a single files output.
@@ -62,6 +62,11 @@ bash interactiveAAXtoMP3 [-a|--advanced] [-h|--help]
 * **--file-naming-scheme &lt;STRING&gt;** or **-F**    Use a custom file naming scheme, with variables. See [below](#custom-naming-scheme) for more info.
 * **--chapter-naming-scheme &lt;STRING&gt;**  Use a custom chapter naming scheme, with variables. See [below](#custom-naming-scheme) for more info.
 
+## Options for interactiveAAXtoMP3
+* **-a** or **--advanced** Get more options to choose. Not used right now.
+* **-h** or **--help** Get a help prompt.
+This script presents you the options you chose last time as default.
+When you get asked for the aax-file you may just drag'n'drop it to the terminal.
 
 ### [AUTHCODE]
 **Your** Audible auth code (it won't correctly decode otherwise) (required).

--- a/interactiveAAXtoMP3
+++ b/interactiveAAXtoMP3
@@ -9,7 +9,7 @@
 
 # ===Variables====================================================================================================================================
 
-# Help mesaage
+# Help message
 help=$'\nUsage: interactiveAAXtoMP3 [--advanced] [--help]\n
 --advanced	More options
 --help		Print this message\n'
@@ -22,11 +22,11 @@ advanced=0         # Toggles advanced options on or off.
 while true; do
   case "$1" in
                      # Advanced options.
-    -a | --advanced  ) advanced=1;                                                                                  shift ;;
+    -a | --advanced  ) advanced=1;      shift ;;
                      # Command synopsis.
-    -h | --help      ) echo -e "$help";                                                                             exit ;;
+    -h | --help      ) echo -e "$help"; exit ;;
                      # Anything else stops command line processing.
-    *                )                                                                                              break ;;
+    *                )                  break ;;
   esac
 done
 
@@ -50,12 +50,36 @@ if ! [[ $(type -P "$SED") ]]; then
   exit 1
 fi
 
+# ===Get options from last time===================================================================================================================
+
+# ===Set default values===
+lastcodec="mp3"
+lastcompression="4"
+lastchapters="yes"
+lastauthcode=""
+lastloglevel="1"
+
+# ===Get Values from last time===
+if [ -f "interactive.txt" ]; then
+  for ((i=1;i<=$(wc -l interactive.txt | cut -d " " -f 1);i++)) do
+    line=$(head -$i interactive.txt | tail -1)
+    case $(echo $line | cut -d " " -f 1 | $SED 's/.$//') in
+      codec        ) lastcodec="$(echo $line | cut -d " " -f 2)";;
+      compression  ) lastcompression="$(echo $line | cut -d " " -f 2)";;
+      chapters     ) lastchapters="$(echo $line | cut -d " " -f 2)";;
+      authcode     ) lastauthcode="$(echo $line | cut -d " " -f 2)";;
+      loglevel     ) lastloglevel="$(echo $line | cut -d " " -f 2)";;
+      *            ) rm interactive.txt; exit 1;;
+    esac
+  done
+fi
+
 # ===Get options for AAXtoMP3=====================================================================================================================
 
 # ===Codec===
 while true; do
   clear;
-  read -p "codec (mp3/m4a/m4b/flac/aac/opus): " codec
+  read -e -p "codec (mp3/m4a/m4b/flac/aac/opus): " -i "$lastcodec" codec
   case "$codec" in
     mp3   ) summary="$summary""codec: $codec"; call="$call -e:mp3"; break;;
     m4a   ) summary="$summary""codec: $codec"; call="$call -e:m4a"; break;;
@@ -75,7 +99,7 @@ while true; do
     opus  ) maxlevel=10;;
     *     ) break;;
   esac
-  read -p "compression level (0-$maxlevel): " compression
+  read -e -p "compression level (0-$maxlevel): " -i "$lastcompression" compression
   if [[ $compression =~ ^[0-9]+$ ]] && [[ "$compression" -ge "0" ]] && [[ "$compression" -le "$maxlevel" ]]; then
     summary="$summary""\ncompression level: $compression"
     call="$call --level $compression"
@@ -86,7 +110,7 @@ done
 # ===Chapters===
 while true; do
   clear; echo -e "$summary"
-  read -p "chapters (yes/no/chapternumber to continue with): " chapters
+  read -e -p "chapters (yes/no/chapternumber to continue with): " -i "$lastchapters" chapters
   case "$chapters" in
     ^[0-9]+$  ) summary="$summary""\nchapters: $chapters"; call="$call -c --continue ${chapters}"; break;;
     yes       ) summary="$summary""\nchapters: $chapters"; call="$call -c"; break;;
@@ -97,7 +121,7 @@ done
 # ===Authcode===
 if ! [ -r .authcode ] || [ -r ~/.authcode ]; then
   clear; echo -e "$summary"
-  read -p "Authcode: " authcode
+  read -e -p "Authcode: " -i "$lastauthcode" authcode
   summary="$summary""\nauthcode: $authcode"
   call="$call -A $authcode"
 fi
@@ -105,7 +129,7 @@ fi
 # ===Loglevel===
 while true; do
   clear; echo -e "$summary"
-  read -p "loglevel (0/1/2/3): " loglevel
+  read -e -p "loglevel (0/1/2/3): " -i "$lastloglevel" loglevel
   if [[ $loglevel =~ ^[0-9]+$ ]] && [[ "$loglevel" -ge "0" ]] && [[ "$loglevel" -le "3" ]]; then
     summary="$summary""\nloglevel: $loglevel"
     call="$call -l $loglevel"
@@ -116,6 +140,9 @@ done
 # ===File===
 clear; echo -e "$summary"
 read -p "aax-file: " file
+file="${file%\'}" #remove suffix ' if file is given via drag'n'drop
+file="${file#\'}" #remove prefix ' if file is given via drag'n'drop
+savefile="$summary"
 summary="$summary""\naax-file: $file"
 call="$call $(echo $file | $SED "s;~;$HOME;")"
 
@@ -124,6 +151,9 @@ call="$call $(echo $file | $SED "s;~;$HOME;")"
 # ===Summary===
 clear; echo -e "$summary\n"
 echo -e "$call\n"
+
+# ===Save chosen options===
+echo -e $savefile | $SED "s;\ level:;:;" > interactive.txt
 
 # ===Call AAXtoMP3===
 $call

--- a/interactiveAAXtoMP3
+++ b/interactiveAAXtoMP3
@@ -60,16 +60,16 @@ lastauthcode=""
 lastloglevel="1"
 
 # ===Get Values from last time===
-if [ -f "interactive.txt" ]; then
-  for ((i=1;i<=$(wc -l interactive.txt | cut -d " " -f 1);i++)) do
-    line=$(head -$i interactive.txt | tail -1)
+if [ -f ".interactivesave" ]; then
+  for ((i=1;i<=$(wc -l .interactivesave | cut -d " " -f 1);i++)) do
+    line=$(head -$i .interactivesave | tail -1)
     case $(echo $line | cut -d " " -f 1 | $SED 's/.$//') in
       codec        ) lastcodec="$(echo $line | cut -d " " -f 2)";;
       compression  ) lastcompression="$(echo $line | cut -d " " -f 2)";;
       chapters     ) lastchapters="$(echo $line | cut -d " " -f 2)";;
       authcode     ) lastauthcode="$(echo $line | cut -d " " -f 2)";;
       loglevel     ) lastloglevel="$(echo $line | cut -d " " -f 2)";;
-      *            ) rm interactive.txt; exit 1;;
+      *            ) rm .interactivesave; exit 1;;
     esac
   done
 fi
@@ -153,7 +153,7 @@ clear; echo -e "$summary\n"
 echo -e "$call\n"
 
 # ===Save chosen options===
-echo -e $savefile | $SED "s;\ level:;:;" > interactive.txt
+echo -e $savefile | $SED "s;\ level:;:;" > .interactivesave
 
 # ===Call AAXtoMP3===
 $call

--- a/interactiveAAXtoMP3
+++ b/interactiveAAXtoMP3
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# ===Note for contributors========================================================================================================================
+
+# This script interactively asks the user for the options to call AAXtoMP3 with. This first version does not include all options of AAXtoMP3
+# since I tried to keep the dialog short, but I added an --advanced option, which is unused right now, but might be used in the future to add
+# more options which only show up if explicitely wanted.
+# If you want to add functionality please consider, whether the functionality you add might belong to the advanced options.
+
+# ===Variables====================================================================================================================================
+
+# Usage synopsis
+usage=$'\nUsage: interactiveAAXtoMP3 [--advanced] [--help]\n'
+# Help mesaage
+help=$'\nUsage: interactiveAAXtoMP3 [--advanced] [--help]\n
+--advanced	More options
+--help		Print this message\n'
+summery=""         # This will contain a summery of the options allready set.
+call="./AAXtoMP3"  # This will contain the call for AAXtoMP3.
+isnum='^[0-9]+$'   # This is needed to check whether a variable is a number.
+advanced=0         # Toggles Advanced options on or off.
+
+# ===Options======================================================================================================================================
+
+while true; do
+  case "$1" in
+                      # Advanced options.
+    -a | --advanced   ) advanced=1;                                                                                  shift ;;
+                      # Command synopsis.
+    -h | --help       ) echo -e "$help";                                                                            exit ;;
+                      # Anything else stops command line processing.
+    *                 ) echo -e "$usage";                                                                            exit ;;
+  esac
+done
+
+# ===Get options for AAXtoMP3=====================================================================================================================
+
+# ===Codec===
+while true; do
+  clear;
+  read -p "codec (mp3/m4a/m4b/flac/aac/opus): " codec
+  if [[ "$codec" = "mp3" ]]; then summery="$summery""codec: $codec"; call="$call -e:mp3"; break
+  elif [[ "$codec" = "m4a" ]]; then summery="$summery""codec: $codec"; call="$call -e:m4a"; break
+  elif [[ "$codec" = "m4b" ]]; then summery="$summery""codec: $codec"; call="$call -e:m4b"; break
+  elif [[ "$codec" = "flac" ]]; then summery="$summery""codec: $codec"; call="$call --flac"; break
+  elif [[ "$codec" = "aac" ]]; then summery="$summery""codec: $codec"; call="$call --aac"; break
+  elif [[ "$codec" = "opus" ]]; then summery="$summery""codec: $codec"; call="$call --opus"; break
+  fi
+done
+
+# ===Compression===
+while true; do
+  clear; echo -e "$summery"
+  if [[ "$codec" = "mp3" ]]; then maxlevel=9
+  elif [[ "$codec" = "flac" ]]; then maxlevel=12
+  elif [[ "$codec" = "opus" ]]; then maxlevel=10
+  else break
+  fi
+  read -p "compression level (0-$maxlevel): " compression
+  if [[ ${compression} =~ $isnum ]] && [[ "$((${compression} > -1))" == "1" ]] && [[ "$((${compression} < ${maxlevel}+1))" == "1" ]]; then
+    summery="$summery""\ncompression level: $compression"
+    call="$call --level $compression"
+    break
+  fi
+done
+
+# ===Chapters===
+while true; do
+  clear; echo -e "$summery"
+  read -p "chapters (yes/no/chapternumber to continue with): " chapters
+  if [[ ${chapters} =~ $isnum ]]; then summery="$summery""\nchapters: $chapters"; call="$call -c --continue ${chapters}"; break
+  elif [[ "$chapters" = "yes" ]] ; then summery="$summery""\nchapters: $chapters"; call="$call -c"; break
+  elif [[ "$chapters" = "no" ]] ; then summery="$summery""\nchapters: $chapters"; call="$call -s"; break
+  fi
+done
+
+# ===Authcode===
+if ! [ -r .authcode ] || [ -r ~/.authcode ]; then
+  clear; echo -e "$summery"
+  read -p "Authcode: " authcode
+  summery="$summery""\nauthcode: $authcode"
+  call="$call -A $authcode"
+fi
+
+# ===Loglevel===
+while true; do
+  clear; echo -e "$summery"
+  read -p "loglevel (0/1/2/3): " loglevel
+  if [[ ${loglevel} =~ $isnum ]] && [[ "$((${loglevel} > -1))" == "1" ]] && [[ "$((${loglevel} < 4))" == "1" ]]; then
+    summery="$summery""\nloglevel: $loglevel"
+    call="$call -l $loglevel"
+    break
+  fi
+done
+
+# ===File===
+clear; echo -e "$summery"
+read -p "aax-file: " file
+summery="$summery""\naax-file: $file"
+call="$call $(echo $file | sed "s;~;$HOME;")"
+
+# ===Summerize chosen options and call AAXtoMP3===================================================================================================
+
+# ===Summery===
+clear; echo -e "$summery\n"
+echo -e "$call\n"
+# -----
+
+# ===Call AAXtoMP3===
+$call

--- a/interactiveAAXtoMP3
+++ b/interactiveAAXtoMP3
@@ -9,29 +9,46 @@
 
 # ===Variables====================================================================================================================================
 
-# Usage synopsis
-usage=$'\nUsage: interactiveAAXtoMP3 [--advanced] [--help]\n'
 # Help mesaage
 help=$'\nUsage: interactiveAAXtoMP3 [--advanced] [--help]\n
 --advanced	More options
 --help		Print this message\n'
-summery=""         # This will contain a summery of the options allready set.
+summary=""         # This will contain a summary of the options allready set.
 call="./AAXtoMP3"  # This will contain the call for AAXtoMP3.
-isnum='^[0-9]+$'   # This is needed to check whether a variable is a number.
-advanced=0         # Toggles Advanced options on or off.
+advanced=0         # Toggles advanced options on or off.
 
 # ===Options======================================================================================================================================
 
 while true; do
   case "$1" in
-                      # Advanced options.
-    -a | --advanced   ) advanced=1;                                                                                  shift ;;
-                      # Command synopsis.
-    -h | --help       ) echo -e "$help";                                                                            exit ;;
-                      # Anything else stops command line processing.
-    *                 ) echo -e "$usage";                                                                            exit ;;
+                     # Advanced options.
+    -a | --advanced  ) advanced=1;                                                                                  shift ;;
+                     # Command synopsis.
+    -h | --help      ) echo -e "$help";                                                                             exit ;;
+                     # Anything else stops command line processing.
+    *                )                                                                                              break ;;
   esac
 done
+
+# ===Cross platform compatible use grep and sed===================================================================================================
+
+# ===Detect which annoying version of grep we have===
+GREP=$(grep --version | grep -q GNU && echo "grep" || echo "ggrep")
+if ! [[ $(type -P "$GREP") ]]; then
+  echo "$GREP (GNU grep) is not in your PATH"
+  echo "Without it, this script will break."
+  echo "On macOS, you may want to try: brew install grep"
+  exit 1
+fi
+
+# ===Detect which annoying version of sed we have===
+SED=$(sed --version 2>&1 | $GREP -q GNU && echo "sed" || echo "gsed")
+if ! [[ $(type -P "$SED") ]]; then
+  echo "$SED (GNU sed) is not in your PATH"
+  echo "Without it, this script will break."
+  echo "On macOS, you may want to try: brew install gnu-sed"
+  exit 1
+fi
 
 # ===Get options for AAXtoMP3=====================================================================================================================
 
@@ -39,26 +56,28 @@ done
 while true; do
   clear;
   read -p "codec (mp3/m4a/m4b/flac/aac/opus): " codec
-  if [[ "$codec" = "mp3" ]]; then summery="$summery""codec: $codec"; call="$call -e:mp3"; break
-  elif [[ "$codec" = "m4a" ]]; then summery="$summery""codec: $codec"; call="$call -e:m4a"; break
-  elif [[ "$codec" = "m4b" ]]; then summery="$summery""codec: $codec"; call="$call -e:m4b"; break
-  elif [[ "$codec" = "flac" ]]; then summery="$summery""codec: $codec"; call="$call --flac"; break
-  elif [[ "$codec" = "aac" ]]; then summery="$summery""codec: $codec"; call="$call --aac"; break
-  elif [[ "$codec" = "opus" ]]; then summery="$summery""codec: $codec"; call="$call --opus"; break
-  fi
+  case "$codec" in
+    mp3   ) summary="$summary""codec: $codec"; call="$call -e:mp3"; break;;
+    m4a   ) summary="$summary""codec: $codec"; call="$call -e:m4a"; break;;
+    m4b   ) summary="$summary""codec: $codec"; call="$call -e:m4b"; break;;
+    flac  ) summary="$summary""codec: $codec"; call="$call --flac"; break;;
+    aac   ) summary="$summary""codec: $codec"; call="$call --aac";  break;;
+    opus  ) summary="$summary""codec: $codec"; call="$call --opus"; break;;
+  esac
 done
 
 # ===Compression===
 while true; do
-  clear; echo -e "$summery"
-  if [[ "$codec" = "mp3" ]]; then maxlevel=9
-  elif [[ "$codec" = "flac" ]]; then maxlevel=12
-  elif [[ "$codec" = "opus" ]]; then maxlevel=10
-  else break
-  fi
+  clear; echo -e "$summary"
+  case "$codec" in
+    mp3   ) maxlevel=9;;
+    flac  ) maxlevel=12;;
+    opus  ) maxlevel=10;;
+    *     ) break;;
+  esac
   read -p "compression level (0-$maxlevel): " compression
-  if [[ ${compression} =~ $isnum ]] && [[ "$((${compression} > -1))" == "1" ]] && [[ "$((${compression} < ${maxlevel}+1))" == "1" ]]; then
-    summery="$summery""\ncompression level: $compression"
+  if [[ $compression =~ ^[0-9]+$ ]] && [[ "$compression" -ge "0" ]] && [[ "$compression" -le "$maxlevel" ]]; then
+    summary="$summary""\ncompression level: $compression"
     call="$call --level $compression"
     break
   fi
@@ -66,45 +85,45 @@ done
 
 # ===Chapters===
 while true; do
-  clear; echo -e "$summery"
+  clear; echo -e "$summary"
   read -p "chapters (yes/no/chapternumber to continue with): " chapters
-  if [[ ${chapters} =~ $isnum ]]; then summery="$summery""\nchapters: $chapters"; call="$call -c --continue ${chapters}"; break
-  elif [[ "$chapters" = "yes" ]] ; then summery="$summery""\nchapters: $chapters"; call="$call -c"; break
-  elif [[ "$chapters" = "no" ]] ; then summery="$summery""\nchapters: $chapters"; call="$call -s"; break
-  fi
+  case "$chapters" in
+    ^[0-9]+$  ) summary="$summary""\nchapters: $chapters"; call="$call -c --continue ${chapters}"; break;;
+    yes       ) summary="$summary""\nchapters: $chapters"; call="$call -c"; break;;
+    no        ) summary="$summary""\nchapters: $chapters"; call="$call -s"; break;;
+  esac
 done
 
 # ===Authcode===
 if ! [ -r .authcode ] || [ -r ~/.authcode ]; then
-  clear; echo -e "$summery"
+  clear; echo -e "$summary"
   read -p "Authcode: " authcode
-  summery="$summery""\nauthcode: $authcode"
+  summary="$summary""\nauthcode: $authcode"
   call="$call -A $authcode"
 fi
 
 # ===Loglevel===
 while true; do
-  clear; echo -e "$summery"
+  clear; echo -e "$summary"
   read -p "loglevel (0/1/2/3): " loglevel
-  if [[ ${loglevel} =~ $isnum ]] && [[ "$((${loglevel} > -1))" == "1" ]] && [[ "$((${loglevel} < 4))" == "1" ]]; then
-    summery="$summery""\nloglevel: $loglevel"
+  if [[ $loglevel =~ ^[0-9]+$ ]] && [[ "$loglevel" -ge "0" ]] && [[ "$loglevel" -le "3" ]]; then
+    summary="$summary""\nloglevel: $loglevel"
     call="$call -l $loglevel"
     break
   fi
 done
 
 # ===File===
-clear; echo -e "$summery"
+clear; echo -e "$summary"
 read -p "aax-file: " file
-summery="$summery""\naax-file: $file"
-call="$call $(echo $file | sed "s;~;$HOME;")"
+summary="$summary""\naax-file: $file"
+call="$call $(echo $file | $SED "s;~;$HOME;")"
 
 # ===Summerize chosen options and call AAXtoMP3===================================================================================================
 
-# ===Summery===
-clear; echo -e "$summery\n"
+# ===Summary===
+clear; echo -e "$summary\n"
 echo -e "$call\n"
-# -----
 
 # ===Call AAXtoMP3===
 $call


### PR DESCRIPTION
This script interactively asks the user for the options to call AAXtoMP3 with.
I only implemented codec, compression, chapters, authcode, loglevel and source file because I wanted the dialog to be short.
If wanted the other options can be added. Preferably in a way that they only appeare if `--advanced` is used.