### PR TITLE
Continue if the current file already exists

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -683,6 +683,7 @@ do
 
   if [[ "${noclobber}" = "1" ]] && [[ -d "${output_directory}" ]]; then
     log "Noclobber enabled but directory '${output_directory}' exists. Skipping to avoid overwriting"
+    rm -f "${metadata_file}"
     continue
   fi
   mkdir -p "${output_directory}"

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -682,8 +682,8 @@ do
   output_file="${output_directory}/${currentFileNameScheme}.${extension}"
 
   if [[ "${noclobber}" = "1" ]] && [[ -d "${output_directory}" ]]; then
-    log "Noclobber enabled but directory '${output_directory}' exists. Exiting to avoid overwriting"
-    exit 0
+    log "Noclobber enabled but directory '${output_directory}' exists. Skipping to avoid overwriting"
+    continue
   fi
   mkdir -p "${output_directory}"
 


### PR DESCRIPTION
I wonder if it doesn't make sense to continue with the remaining files if one of them has already been fully processed.
This way the script can continue to run and you don't have to manually check which file is not finished yet?