### PR TITLE
Fixing `,000` issue with mp4chaps

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -955,6 +955,7 @@ do
       else
         "$FFPROBE" -i "${aax_file}" -print_format csv -show_chapters 2>/dev/null | awk -F "," '{printf "CHAPTER%d=%02d:%02d:%02.3f\nCHAPTER%dNAME=%s\n", NR, $5/60/60, $5/60%60, $5%60, NR, $8}' > "${output_directory}/${currentFileNameScheme}.chapters.txt"
       fi
+      $SED -i 's/\,000/\.000/' "${output_directory}/${currentFileNameScheme}.chapters.txt"
       mp4chaps -i "${output_file}"
     fi
   fi


### PR DESCRIPTION
Replaces the `,000` in the chapters.txt file with `.000` to allow processing with `mp4chaps`