### PR TITLE
feat: Use ffmpeg to cover add instead of mp4art

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -962,7 +962,23 @@ do
 
   if [ -f "${cover_file}" ]; then
     log "Adding cover art"
-    mp4art --add "${cover_file}" "${output_file}"
+    # Create temporary output file name - ensure extention matches previous appropriate output file to keep ffmpeg happy
+    cover_output_file="${output_file%.*}.cover.${output_file##*.}"
+    # Copy audio stream from current output, and video stream from cover file, setting appropriate metadata
+    </dev/null "$FFMPEG" -loglevel quiet \
+      -nostats \
+      -i "${output_file}" \
+      -i "${cover_file}" \
+      -map 0:a:0 \
+      -map 1:v:0 \
+      -acodec copy \
+      -vcodec copy \
+      -id3v2_version 3 \
+      -metadata:s:v title="Album cover" \
+      -metadata:s:v comment="Cover (front)" \
+      "${cover_output_file}"
+      # Replace original output file with version including cover
+      mv "${cover_output_file}" "${output_file}"
   fi
 
   # -----

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Audible fails for some reason.
 * GNU sed - see above
 * GNU find - see above
 * jq - only if `--use-audible-cli-data` is set or if converting an .aaxc file
-* mp4art used to add cover art to m4a and m4b files. Optional
 * mediainfo used to add additional media tags like narrator. Optional
 
 ## Usage(s)
@@ -209,24 +208,6 @@ brew install ffmpeg
 brew install gnu-sed
 brew install grep
 brew install findutils
-```
-
-#### mp4art/mp4chaps
-_Note: This is an optional dependency._
-
-__Ubuntu, Linux Mint, Debian__
-```
-sudo apt-get update
-sudo apt-get install mp4v2-utils
-```
-__CentOS, RHEL & Fedora__
-```
-# CentOS/RHEL and Fedora users make sure that you have enabled atrpms repository in system. Let’s begin installing FFmpeg as per your operating system.
-yum install mp4v2-utils
-```
-__MacOS__
-```
-brew install mp4v2
 ```
 
 #### mediainfo


### PR DESCRIPTION
Use ffmpeg to cover add instead of mp4art from deprecated mp4v2-utils package

closes: https://github.com/KrumpetPirate/AAXtoMP3/issues/198