### PR TITLE
fix: video stream metadata for front cover comment should be lower ca…

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -913,7 +913,7 @@ do
             -map 1:0 \
             -acodec ${chapter_codec} \
             -metadata:s:v title="Album cover" \
-            -metadata:s:v comment="Cover (Front)" \
+            -metadata:s:v comment="Cover (front)" \
             -metadata track="${chapternum}" \
             -metadata title="${chapter}" \
             -metadata:s:a title="${chapter}" \


### PR DESCRIPTION
fix: video stream metadata for front cover comment should be lower case _front_

Minor issue, but some people have found cover art does not work on some systems if all the metadata is not completely correct.