### PR TITLE
Fixes for jq command generating chapters.txt

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -551,9 +551,10 @@ save_metadata() {
       jq -r \
         'def pad(n): tostring | if (n > length) then ((n - length) * "0") + . else . end;
         .content_metadata.chapter_info.chapters |
+        reduce .[] as $c ([]; if $c.chapters? then .+[$c | del(.chapters)]+[$c.chapters] else .+[$c] end) | flatten |
         to_entries |
         .[] |
-        "CHAPTER\((.key))=\(((.value.start_offset_ms / (1000*60*60)) %24 | floor | pad(2))):\(((.value.start_offset_ms / (1000*60)) %60 | floor | pad(2))):\(((.value.start_offset_ms / 1000) %60 | floor | pad(2))).\((.value.start_offset_ms % 1000 | pad(3)))
+        "CHAPTER\((.key))=\((((((.value.start_offset_ms / (1000*60*60)) /24 | floor)  *24 ) + ((.value.start_offset_ms / (1000*60*60)) %24 | floor)) | pad(2))):\(((.value.start_offset_ms / (1000*60)) %60 | floor | pad(2))):\(((.value.start_offset_ms / 1000) %60 | floor | pad(2))).\((.value.start_offset_ms % 1000 | pad(3)))
 CHAPTER\((.key))NAME=\(.value.title)"' "${extra_chapter_file}" > "${tmp_chapter_file}"
     fi
 


### PR DESCRIPTION
Fixes #184

Adds a reduce + flatten step to generate a flat list of chapters.

Fixes #206

Support for emitting timestamps greater than 24 hours.

See https://jqplay.org/s/pcLohUSDGZ for test.