### PR TITLE
Limit result to one line when parsing cover size.

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -807,7 +807,7 @@ do
   fi
 
   extra_crop_cover=''
-  cover_width=$(ffprobe -i "${cover_file}" 2>&1 | $GREP -Po "[0-9]+(?=x[0-9]+)")
+  cover_width=$(ffprobe -i "${cover_file}" 2>&1 | $GREP -Po "[0-9]+(?=x[0-9]+)" | tail -n 1)
   if (( ${cover_width} % 2 == 1 )); then
     if [ "$((${loglevel} > 1))" == "1" ]; then
       log "Cover ${cover_file} has odd width ${cover_width}, setting extra_crop_cover to make even."


### PR DESCRIPTION
Fixes #210.

I think this is more like a hack, but it does produce more sensible results.