### PR TITLE
Add condition on cover addition if the mode is chaptered

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -967,7 +967,7 @@ do
     fi
   fi
 
-  if [ -f "${cover_file}" ]; then
+  if [ -f "${cover_file}" ] && [ "${mode}" != "chaptered" ] ; then
     log "Adding cover art"
     # FFMGEP does not support MPEG-4 containers fully #
     if [ "${container}" == "mp4" ] ; then


### PR DESCRIPTION
When I tried to transform a aaxc with a cover to the default it crashed due to the fact it tries to add a cover to a non existent file due to the chaptering done before