### PR TITLE
Remove colon from metadata

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -585,7 +585,7 @@ get_metadata_value() {
   local key
   key="$1"
         # Find the key in the meta data file                                  # Extract field value     # Remove the following /'s  "(Unabridged)  <blanks> at start end and multiples.
-  echo "$($GREP --max-count=1 --only-matching "${key} *: .*" "$metadata_file" | cut -d : -f 2- | $SED -e 's#/##g;s/ (Unabridged)//;s/^[[:blank:]]\+//g;s/[[:blank:]]\+$//g' | $SED 's/[[:blank:]]\+/ /g')"
+  echo "$($GREP --max-count=1 --only-matching "${key} *: .*" "$metadata_file" | cut -d : -f 2- | $SED -e 's#/##g;s/ (Unabridged)//;s/^[[:blank:]]\+//g;s/[[:blank:]]\+$//g' | $SED 's/[[:blank:]]\+/ /g' | $SED 's/\:/_/g')"
 }
 
 # -----


### PR DESCRIPTION
This will help prevent issues on linux based operating systems where it cannot make the directories in the event any of the metadata (like the book name) includes a colon.