### PR TITLE
stop error when splitting to chapters using mp4 format

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -970,7 +970,7 @@ do
   if [ -f "${cover_file}" ]; then
     log "Adding cover art"
     # FFMPEG does not support MPEG-4 containers fully #
-    if [ "${container}" == "mp4" -a -f ${output_file} ] ; then
+    if [ "${container}" == "mp4" -a -f "${output_file}" ] ; then
       mp4art --add "${cover_file}" "${output_file}"
     # FFMPEG for everything else #
     else

--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -970,7 +970,7 @@ do
   if [ -f "${cover_file}" ]; then
     log "Adding cover art"
     # FFMPEG does not support MPEG-4 containers fully #
-    if [ "${container}" == "mp4" ] ; then
+    if [ "${container}" == "mp4" -a -f ${output_file} ] ; then
       mp4art --add "${cover_file}" "${output_file}"
     # FFMPEG for everything else #
     else


### PR DESCRIPTION
the main output_file is deleted after splitting into chapters causing an error when trying to tag output_file with cover art